### PR TITLE
Fixed tests and PHPStan errors

### DIFF
--- a/src/bundle/Resources/views/themes/standard/design_system/partials/base_field.html.twig
+++ b/src/bundle/Resources/views/themes/standard/design_system/partials/base_field.html.twig
@@ -1,4 +1,4 @@
-{% set classes = html_classes('ids-field', 'ids-field--' ~ type, class) %}
+{% set classes = html_classes('ids-field', 'ids-field--' ~ type, attributes.render('class') ?? '') %}
 
 <div class="{{ classes }}" {{ attributes }}>
     {% if block('label') is defined and block('label') is not empty %}

--- a/src/lib/Twig/Components/RadioButton/ListField.php
+++ b/src/lib/Twig/Components/RadioButton/ListField.php
@@ -13,14 +13,24 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
+/**
+ * @phpstan-type RadioButtonItem array{
+ *     value: string|int,
+ *     label: string,
+ *     disabled?: bool
+ * }
+ * @phpstan-type RadioButtonItems list<RadioButtonItem>
+ */
 #[AsTwigComponent('ibexa:radio_button:list_field')]
 final class ListField extends AbstractField
 {
     public string $direction = 'vertical';
 
+    /** @var RadioButtonItems */
     #[ExposeInTemplate(name: 'items', getter: 'getItems')]
     public array $items = [];
 
+    /** @return RadioButtonItems */
     public function getItems(): array
     {
         return array_map(function ($item) {


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixes
```
  Line   src/lib/Twig/Components/RadioButton/ListField.php                                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  22     Property Ibexa\DesignSystemTwig\Twig\Components\RadioButton\ListField::$items type has no value type specified in iterable type array.           
         🪪  missingType.iterableValue                                                                                                                    
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                       
  24     Method Ibexa\DesignSystemTwig\Twig\Components\RadioButton\ListField::getItems() return type has no value type specified in iterable type array.  
         🪪  missingType.iterableValue                                                                                                                    
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type      
```
and 
```
Trzeci argument powinien pobrać klasę przez `attributes.render('class')`
1) Ibexa\Tests\Integration\DesignSystemTwig\Twig\Components\InputText\FieldTest::testDefaultRenderProducesInputWithCoreAttributes
Twig\Error\RuntimeError: Variable "class" does not exist in "@IbexaDesignSystemTwig/themes/standard/design_system/partials/base_field.html.twig" at line 1.
``` 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
