### PR TITLE
Improved check if content is not empty

### DIFF
--- a/src/bundle/Resources/views/themes/standard/design_system/components/button.html.twig
+++ b/src/bundle/Resources/views/themes/standard/design_system/components/button.html.twig
@@ -1,5 +1,6 @@
-{% set content_block = block('content') is defined ? block('content')|trim : '' %}
-{% set icon_only = content_block == '' and icon is not empty %}
+{% set _content %}{% block content %}{% endblock %}{% endset %}
+{% set has_content = _content|striptags|trim is not empty %}
+{% set icon_only = (not has_content) and icon is not empty %}
 {% set button_classes =
     html_cva(
         base: html_classes(
@@ -50,7 +51,7 @@
         {% endblock icon_outer %}
         {% if not icon_only %}
             <div class="ids-btn__label">
-                {{ content_block|raw }}
+                {{ _content|raw }}
             </div>
         {% endif %}
     {% endblock button_inner %}

--- a/src/bundle/Resources/views/themes/standard/design_system/components/helper_text.html.twig
+++ b/src/bundle/Resources/views/themes/standard/design_system/components/helper_text.html.twig
@@ -1,4 +1,5 @@
-{% set has_content = block('content')|trim != '' %}
+{% set _content %}{% block content %}{% endblock %}{% endset %}
+{% set has_content = _content|striptags|trim is not empty %}
 
 {% if has_content %}
     {% set helper_text_classes =
@@ -40,9 +41,7 @@
             {% endblock icon_outer %}
             {% block content_outer %}
                 <div class="ids-helper-text__content-wrapper">
-                    {% block content %}
-
-                    {% endblock content %}
+                    {{ _content }}
                 </div>
             {% endblock content_outer %}
         {% endblock helper_text_inner %}


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
We cannot move the “has content” check for the content block into the PHP side of a Symfony UX Twig Component, because the component class has no access to the rendered output of Twig blocks/slots. Blocks are resolved only during template rendering, so from PHP, you cannot reliably know if the content slot is empty or not.

We will keep the check in Twig, but avoid repeated block('content') calls by buffering the block once into a variable.
```
{% set _content %}{% block content %}{% endblock %}{% endset %}
{% set has_content = _content|striptags|trim is not empty %}
``` 
This way _content can be reused wherever needed, and has_content gives a clean boolean to control conditional rendering. If further centralization is desired, a small Twig filter/test or a helper method can process _content, but the capture of the block itself must remain in Twig.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
