### PR TITLE
IBX-12188: Added Alert component

### DIFF
--- a/src/bundle/Resources/public/ts/components/alert.ts
+++ b/src/bundle/Resources/public/ts/components/alert.ts
@@ -1,0 +1,53 @@
+import { Base } from '../partials';
+
+const EVENT_DISMISS_BEFORE = 'ids:alert:dismiss:before';
+const EVENT_DISMISSED = 'ids:alert:dismissed';
+
+export class Alert extends Base {
+    private closeBtn: HTMLButtonElement | null;
+
+    constructor(container: HTMLDivElement) {
+        super(container);
+
+        this.closeBtn = this._container.querySelector('.ids-alert__close-btn');
+    }
+
+    protected handleCloseClick(event: MouseEvent): void {
+        event.stopPropagation();
+
+        this.dismiss();
+    }
+
+    public dismiss(): void {
+        const dismissBeforeEvent = new CustomEvent(EVENT_DISMISS_BEFORE, {
+            cancelable: true,
+            detail: {
+                component: this,
+            },
+        });
+
+        this._container.dispatchEvent(dismissBeforeEvent);
+
+        if (dismissBeforeEvent.defaultPrevented) {
+            return;
+        }
+
+        this._container.remove();
+        this._container.dispatchEvent(
+            new CustomEvent(EVENT_DISMISSED, {
+                detail: {
+                    component: this,
+                },
+            }),
+        );
+    }
+
+    protected initCloseBtn(): void {
+        this.closeBtn?.addEventListener('click', this.handleCloseClick.bind(this));
+    }
+
+    public init(): void {
+        super.init();
+        this.initCloseBtn();
+    }
+}

--- a/src/bundle/Resources/public/ts/init_components.ts
+++ b/src/bundle/Resources/public/ts/init_components.ts
@@ -5,6 +5,7 @@ import { InputTextField, InputTextInput } from './components/input_text';
 import { RadioButtonInput, RadioButtonsListField } from './components/radio_button';
 import { ToggleButtonField, ToggleButtonInput } from './components/toggle_button';
 import { Accordion } from './components/accordion';
+import { Alert } from './components/alert';
 import { OverflowList } from './components/overflow_list';
 
 const accordionContainers = document.querySelectorAll<HTMLDivElement>('.ids-accordion:not([data-ids-custom-init])');
@@ -13,6 +14,14 @@ accordionContainers.forEach((accordionContainer: HTMLDivElement) => {
     const accordionInstance = new Accordion(accordionContainer);
 
     accordionInstance.init();
+});
+
+const alertContainers = document.querySelectorAll<HTMLDivElement>('.ids-alert:not([data-ids-custom-init])');
+
+alertContainers.forEach((alertContainer: HTMLDivElement) => {
+    const alertInstance = new Alert(alertContainer);
+
+    alertInstance.init();
 });
 
 const altRadioContainers = document.querySelectorAll<HTMLDivElement>('.ids-alt-radio:not([data-ids-custom-init])');

--- a/src/bundle/Resources/translations/ibexa_design_system_twig.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_design_system_twig.en.xliff
@@ -6,6 +6,11 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
+      <trans-unit id="1d77b9dc9a4237d80b69c86aee23cf9bdff5c0e8" resname="ibexa.alert.close-btn.label">
+        <source>Close</source>
+        <target state="new">Close</target>
+        <note>key: ibexa.alert.close-btn.label</note>
+      </trans-unit>
       <trans-unit id="09975764bd5f4def61682516d7430651e5b8779e" resname="ibexa.chip.delete-btn.label">
         <source>Delete</source>
         <target state="new">Delete</target>

--- a/src/bundle/Resources/views/themes/standard/design_system/components/alert.html.twig
+++ b/src/bundle/Resources/views/themes/standard/design_system/components/alert.html.twig
@@ -41,7 +41,7 @@
         <twig:ibexa:icon name="{{ icon_name }}" size="small" class="ids-alert__icon" />
     {% endif %}
     <div class="ids-alert__content">
-        {% if title is not empty %}
+        {% if (title ~ '') is not empty %}
             <div class="ids-alert__title">{{ title }}</div>
         {% endif %}
         {% if has_description %}

--- a/src/bundle/Resources/views/themes/standard/design_system/components/alert.html.twig
+++ b/src/bundle/Resources/views/themes/standard/design_system/components/alert.html.twig
@@ -1,0 +1,67 @@
+{% trans_default_domain 'ibexa_design_system_twig' %}
+
+{% set alert_classes =
+    html_cva(
+        base: 'ids-alert',
+        variants: {
+            type: {
+                success: 'ids-alert--success',
+                warning: 'ids-alert--warning',
+                error: 'ids-alert--error',
+                info: 'ids-alert--info',
+            },
+            variant: {
+                floating: 'ids-alert--floating',
+                local: 'ids-alert--local',
+                toast: 'ids-alert--toast',
+            },
+        },
+    )
+%}
+{% set close_msg = 'ibexa.alert.close-btn.label'|trans|desc('Close') %}
+{% set has_description = block('content') is defined and block('content')|trim is not empty %}
+{% set has_actions = block('actions') is defined and block('actions')|trim is not empty %}
+
+<div
+    class="{{
+        alert_classes.apply(
+            {
+                type,
+                variant
+            },
+            attributes.render('class')
+        )
+    }}"
+    role="{{ resolved_role }}"
+    {{ attributes }}
+>
+    {% if icon_path is not empty %}
+        <twig:ibexa:icon path="{{ icon_path }}" size="small" class="ids-alert__icon" />
+    {% else %}
+        <twig:ibexa:icon name="{{ icon_name }}" size="small" class="ids-alert__icon" />
+    {% endif %}
+    <div class="ids-alert__content">
+        {% if title is not empty %}
+            <div class="ids-alert__title">{{ title }}</div>
+        {% endif %}
+        {% if has_description %}
+            <div class="ids-alert__description">
+                {{ block('content') }}
+            </div>
+        {% endif %}
+        {% if has_actions %}
+            <div class="ids-alert__actions">
+                {{ block('actions') }}
+            </div>
+        {% endif %}
+    </div>
+    {% if is_dismissible %}
+        <twig:ibexa:button
+            type="tertiary-alt"
+            size="small"
+            icon="discard"
+            class="ids-alert__close-btn"
+            :aria-label="close_msg"
+        />
+    {% endif %}
+</div>

--- a/src/lib/Twig/Components/Alert.php
+++ b/src/lib/Twig/Components/Alert.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\DesignSystemTwig\Twig\Components;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Symfony\UX\TwigComponent\Attribute\PreMount;
+
+#[AsTwigComponent('ibexa:alert')]
+final class Alert
+{
+    private const ICONS_TYPE_MAP = [
+        'success' => 'check-circle',
+        'warning' => 'alert-warning',
+        'error' => 'alert-error',
+        'info' => 'info-rounded',
+    ];
+
+    private const ROLES_TYPE_MAP = [
+        'success' => 'status',
+        'warning' => 'alert',
+        'error' => 'alert',
+        'info' => 'status',
+    ];
+
+    public string $type;
+
+    public string $variant = 'floating';
+
+    public string $title = '';
+
+    public string $icon = '';
+
+    #[ExposeInTemplate('icon_path')]
+    public string $iconPath = '';
+
+    #[ExposeInTemplate('is_dismissible')]
+    public bool $isDismissible = false;
+
+    public string $role = '';
+
+    /**
+     * @param array<string, mixed> $props
+     *
+     * @return array<string, mixed>
+     */
+    #[PreMount]
+    public function validate(array $props): array
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setIgnoreUndefined();
+        $resolver
+            ->define('type')
+            ->required()
+            ->allowedValues(...array_keys(self::ICONS_TYPE_MAP));
+        $resolver
+            ->define('variant')
+            ->allowedValues('floating', 'local', 'toast')
+            ->default('floating');
+        $resolver
+            ->define('title')
+            ->allowedTypes('string')
+            ->default('');
+        $resolver
+            ->define('icon')
+            ->allowedTypes('string')
+            ->default('');
+        $resolver
+            ->define('iconPath')
+            ->allowedTypes('string')
+            ->default('');
+        $resolver
+            ->define('isDismissible')
+            ->allowedTypes('bool')
+            ->default(false);
+        $resolver
+            ->define('role')
+            ->allowedValues('alert', 'status');
+
+        return $resolver->resolve($props) + $props;
+    }
+
+    #[ExposeInTemplate('icon_name')]
+    public function getIconName(): string
+    {
+        return $this->icon !== '' ? $this->icon : self::ICONS_TYPE_MAP[$this->type];
+    }
+
+    #[ExposeInTemplate('resolved_role')]
+    public function getResolvedRole(): string
+    {
+        return $this->role !== '' ? $this->role : self::ROLES_TYPE_MAP[$this->type];
+    }
+}

--- a/src/lib/Twig/Components/Alert.php
+++ b/src/lib/Twig/Components/Alert.php
@@ -34,7 +34,7 @@ final class Alert
 
     public string $variant = 'floating';
 
-    public string $title = '';
+    public string|\Stringable $title = '';
 
     public string $icon = '';
 
@@ -66,7 +66,7 @@ final class Alert
             ->default('floating');
         $resolver
             ->define('title')
-            ->allowedTypes('string')
+            ->allowedTypes('string', \Stringable::class)
             ->default('');
         $resolver
             ->define('icon')

--- a/tests/integration/Twig/Components/AlertTest.php
+++ b/tests/integration/Twig/Components/AlertTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\UX\TwigComponent\Test\InteractsWithTwigComponents;
 use Twig\Environment;
+use Twig\Markup;
 
 final class AlertTest extends KernelTestCase
 {
@@ -194,6 +195,18 @@ final class AlertTest extends KernelTestCase
     {
         $this->expectException(MissingOptionsException::class);
         $this->mountTwigComponent(Alert::class, ['title' => 'No type']);
+    }
+
+    public function testMarkupTitleIsRenderedRaw(): void
+    {
+        $crawler = $this->renderTwigComponent(
+            Alert::class,
+            ['type' => 'info', 'title' => new Markup('Exit with <svg class="test-icon"></svg> or Esc', 'UTF-8')]
+        )->crawler();
+        $title = $crawler->filter('.ids-alert__title')->first();
+
+        self::assertGreaterThan(0, $title->count(), 'Markup titles should render the title element.');
+        self::assertCount(1, $title->filter('svg.test-icon'), 'Markup titles should be rendered unescaped, like legacy alert titles.');
     }
 
     public function testDescriptionOnlyRendersNoTitle(): void

--- a/tests/integration/Twig/Components/AlertTest.php
+++ b/tests/integration/Twig/Components/AlertTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\DesignSystemTwig\Twig\Components;
+
+use Generator;
+use Ibexa\DesignSystemTwig\Twig\Components\Alert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\UX\TwigComponent\Test\InteractsWithTwigComponents;
+use Twig\Environment;
+
+final class AlertTest extends KernelTestCase
+{
+    use InteractsWithTwigComponents;
+
+    private const REQUIRED_PROPS = [
+        'type' => 'success',
+        'title' => 'Alert title',
+    ];
+
+    public function testMount(): void
+    {
+        $component = $this->mountTwigComponent(Alert::class, [
+            'type' => 'warning',
+            'variant' => 'local',
+            'title' => 'Warning',
+            'icon' => 'lock',
+            'isDismissible' => true,
+            'role' => 'status',
+        ]);
+
+        self::assertInstanceOf(Alert::class, $component, 'Component should mount as Alert.');
+    }
+
+    public function testDefaultRenderProducesClassPlan(): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, self::REQUIRED_PROPS)->crawler();
+        $wrapper = $this->getWrapper($crawler);
+        $class = $this->getClassAttr($wrapper);
+
+        self::assertStringContainsString('ids-alert--success', $class, 'Type modifier should be present.');
+        self::assertStringContainsString('ids-alert--floating', $class, 'Default variant modifier should be "floating".');
+        self::assertSame('status', $wrapper->attr('role'), 'Success alerts should default to role="status".');
+        self::assertCount(1, $crawler->filter('.ids-alert > .ids-alert__icon'), 'Icon should be a direct child of the root.');
+        self::assertCount(1, $crawler->filter('.ids-alert > .ids-alert__content > .ids-alert__title'), 'Title should be rendered inside the content wrapper.');
+        self::assertSame('Alert title', trim($crawler->filter('.ids-alert__title')->text('')), 'Title text should be rendered.');
+        self::assertCount(0, $crawler->filter('.ids-alert__description'), 'Description should not be rendered without content.');
+        self::assertCount(0, $crawler->filter('.ids-alert__actions'), 'Actions should not be rendered without the actions block.');
+        self::assertCount(0, $crawler->filter('.ids-alert__close-btn'), 'Close button should not be rendered by default.');
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     * @param list<string> $expectedClasses
+     */
+    #[DataProvider('variantProvider')]
+    public function testVariantsProduceExpectedClasses(array $props, array $expectedClasses): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, $props + self::REQUIRED_PROPS)->crawler();
+        $class = $this->getClassAttr($this->getWrapper($crawler));
+
+        foreach ($expectedClasses as $expectedClass) {
+            self::assertStringContainsString($expectedClass, $class, sprintf('Expected class "%s" should be present.', $expectedClass));
+        }
+    }
+
+    public static function variantProvider(): Generator
+    {
+        foreach (['success', 'warning', 'error', 'info'] as $type) {
+            yield "type: {$type}" => [['type' => $type], ["ids-alert--{$type}"]];
+        }
+
+        foreach (['floating', 'local', 'toast'] as $variant) {
+            yield "variant: {$variant}" => [['variant' => $variant], ["ids-alert--{$variant}"]];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     * @param non-empty-string $expectedHrefSuffix
+     */
+    #[DataProvider('iconProvider')]
+    public function testIconResolution(array $props, string $expectedHrefSuffix): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, $props + self::REQUIRED_PROPS)->crawler();
+        $use = $crawler->filter('.ids-alert__icon use')->first();
+
+        self::assertGreaterThan(0, $use->count(), 'Icon should render a <use> element.');
+        self::assertStringEndsWith($expectedHrefSuffix, (string) $use->attr('xlink:href'), 'Icon href should resolve as expected.');
+    }
+
+    public static function iconProvider(): Generator
+    {
+        yield 'success default' => [['type' => 'success'], '#check-circle'];
+
+        yield 'warning default' => [['type' => 'warning'], '#alert-warning'];
+
+        yield 'error default' => [['type' => 'error'], '#alert-error'];
+
+        yield 'info default' => [['type' => 'info'], '#info-rounded'];
+
+        yield 'icon override' => [['icon' => 'lock'], '#lock'];
+
+        yield 'iconPath override wins' => [['icon' => 'lock', 'iconPath' => '/custom/sprite.svg#hide'], '/custom/sprite.svg#hide'];
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     */
+    #[DataProvider('roleProvider')]
+    public function testRoleResolution(array $props, string $expectedRole): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, $props + self::REQUIRED_PROPS)->crawler();
+
+        self::assertSame($expectedRole, $this->getWrapper($crawler)->attr('role'), 'Role should be derived from type unless overridden.');
+    }
+
+    public static function roleProvider(): Generator
+    {
+        yield 'success -> status' => [['type' => 'success'], 'status'];
+
+        yield 'info -> status' => [['type' => 'info'], 'status'];
+
+        yield 'warning -> alert' => [['type' => 'warning'], 'alert'];
+
+        yield 'error -> alert' => [['type' => 'error'], 'alert'];
+
+        yield 'error with role override' => [['type' => 'error', 'role' => 'status'], 'status'];
+    }
+
+    public function testDismissibleRendersCloseButton(): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, ['isDismissible' => true] + self::REQUIRED_PROPS)->crawler();
+        $closeBtn = $crawler->filter('.ids-alert > button.ids-alert__close-btn')->first();
+
+        self::assertGreaterThan(0, $closeBtn->count(), 'Close button should be rendered when isDismissible is true.');
+        self::assertStringContainsString('ids-btn--tertiary-alt', $this->getClassAttr($closeBtn), 'Close button should be a tertiary-alt button.');
+        self::assertStringContainsString('ids-btn--small', $this->getClassAttr($closeBtn), 'Close button should be small.');
+        self::assertSame('Close', $closeBtn->attr('aria-label'), 'Close button should carry a translated aria-label.');
+    }
+
+    public function testContentBlockRendersDescription(): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, self::REQUIRED_PROPS, 'Alert <strong>description</strong>')->crawler();
+        $description = $crawler->filter('.ids-alert__content > .ids-alert__description')->first();
+
+        self::assertGreaterThan(0, $description->count(), 'Description should be rendered inside the content wrapper.');
+        self::assertCount(1, $description->filter('strong'), 'Description block should keep its markup.');
+    }
+
+    public function testActionsBlockRendersActions(): void
+    {
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $html = $twig->createTemplate(
+            <<<'TWIG'
+            <twig:ibexa:alert type="success" title="Alert title">
+                <twig:block name="content">Description</twig:block>
+                <twig:block name="actions"><a href="#" class="test-action">Action</a></twig:block>
+            </twig:ibexa:alert>
+            TWIG
+        )->render();
+        $crawler = new Crawler($html);
+        $actions = $crawler->filter('.ids-alert__content > .ids-alert__actions')->first();
+
+        self::assertGreaterThan(0, $actions->count(), 'Actions should be rendered inside the content wrapper.');
+        self::assertCount(1, $actions->filter('.test-action'), 'Actions block content should be rendered.');
+        self::assertCount(1, $crawler->filter('.ids-alert__description'), 'Description should still be rendered next to the actions.');
+    }
+
+    public function testAttributesMergeClass(): void
+    {
+        $crawler = $this->renderTwigComponent(
+            Alert::class,
+            ['attributes' => ['class' => 'extra-class', 'data-test' => 'alert']] + self::REQUIRED_PROPS
+        )->crawler();
+        $wrapper = $this->getWrapper($crawler);
+
+        self::assertStringContainsString('extra-class', $this->getClassAttr($wrapper), 'Custom class should be merged into the root class attribute.');
+        self::assertSame('alert', $wrapper->attr('data-test'), 'Extra attributes should be rendered on the root.');
+    }
+
+    public function testMissingTypeCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(MissingOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['title' => 'No type']);
+    }
+
+    public function testDescriptionOnlyRendersNoTitle(): void
+    {
+        $crawler = $this->renderTwigComponent(Alert::class, ['type' => 'info'], 'Description only')->crawler();
+
+        self::assertCount(0, $crawler->filter('.ids-alert__title'), 'Title should not be rendered when empty.');
+        self::assertCount(1, $crawler->filter('.ids-alert__description'), 'Description should be rendered without a title.');
+    }
+
+    public function testInvalidTypeValueCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['type' => 'danger'] + self::REQUIRED_PROPS);
+    }
+
+    public function testInvalidVariantValueCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['variant' => 'inline'] + self::REQUIRED_PROPS);
+    }
+
+    public function testInvalidRoleValueCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['role' => 'note'] + self::REQUIRED_PROPS);
+    }
+
+    public function testInvalidTitleTypeCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['type' => 'info', 'title' => ['not', 'a', 'string']]);
+    }
+
+    public function testInvalidIsDismissibleTypeCausesResolverErrorOnMount(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->mountTwigComponent(Alert::class, ['isDismissible' => 'yes'] + self::REQUIRED_PROPS);
+    }
+
+    private function getWrapper(Crawler $crawler): Crawler
+    {
+        $node = $crawler->filter('div.ids-alert')->first();
+        self::assertGreaterThan(0, $node->count(), 'Alert root ".ids-alert" should be present.');
+
+        return $node;
+    }
+
+    private function getClassAttr(Crawler $node): string
+    {
+        return (string) $node->attr('class');
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-12188 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/design-system/pull/134
- https://github.com/ibexa/admin-ui/pull/2034
- https://github.com/ibexa/share/pull/198
- https://github.com/ibexa/workflow/pull/203
- https://github.com/ibexa/image-editor/pull/144
- https://github.com/ibexa/personalization/pull/420
- https://github.com/ibexa/connector-ai/pull/210
- https://github.com/ibexa/product-catalog/pull/1577
- https://github.com/ibexa/page-builder/pull/588
- https://github.com/ibexa/connector-qualifio/pull/62

#### Description:
Twig counterpart of the design-system `Alert` (`<twig:ibexa:alert type variant title icon iconPath isDismissible role>` + blocks `content` and `actions`), emitting the same `ids-alert*` classes as the React component, with a vanilla TS behaviour for the close button (cancelable `ids:alert:dismiss:before`, then `remove()`, then `ids:alert:dismissed`; public `dismiss()`).

Merge order: after the design-system PR (needs the new `_alert.scss`).

#### For QA:
`tests/integration/Twig/Components/AlertTest.php` covers the class plan; visual check through the admin-ui PR.

#### Documentation:
